### PR TITLE
Update metrics job

### DIFF
--- a/configs/aws_ec2_plugin.yaml
+++ b/configs/aws_ec2_plugin.yaml
@@ -276,7 +276,7 @@ jenkins:
         hostKeyVerificationStrategy: ACCEPT_NEW
         iamInstanceProfile: ${/jenkins/config/instanceprofile}
         idleTerminationMinutes: "30"
-        labelString: "windows-latest windows-8fe4037c"
+        labelString: "windows-8fe4037c"
         launchTimeoutStr: "600"
         maxTotalUses: 1
         metadataEndpointEnabled: true

--- a/jobdsl/pipeline_metrics_upload_nightly.groovy
+++ b/jobdsl/pipeline_metrics_upload_nightly.groovy
@@ -45,15 +45,6 @@ freeStyleJob('pipeline_metrics_upload_nightly') {
         shell('''
             set +x
 
-            # Grab the private IP of the load balancer to allow the EC2 instance to use the security group allowlist
-            jenkinsip=$(aws ec2 describe-network-interfaces --filters Name=description,Values="ELB app/prod-jenkins-server/2af6c1cd4bb121e7" --query 'NetworkInterfaces[*].PrivateIpAddresses[*].PrivateIpAddress' --output text | head -n1 | tr -d '\\r')
-
-            # Create a new hosts entry for the private IP. Note: The hosts file path only works for Windows Cygwin
-            echo $jenkinsip jenkins-pipeline.agscollab.com | tee -a /cygdrive/c/Windows/system32/drivers/etc/hosts
-        '''.stripIndent().trim())
-        shell('''
-            set +x
-
             export AWS_STS_REGIONAL_ENDPOINTS=regional
             export ASSUME_ROLE_ARN=arn:aws:iam::646296105064:role/s3_for_ec2bi-lumberyard
 


### PR DESCRIPTION
This change fixes an issue with the metrics upload job. It was grabbing the IP of the wrong ELB. Fixed by removing this step since we no longer need to grab the private IP of the jenkins server. 