### PR TITLE
Update AMI ID for Windows build nodes

### DIFF
--- a/configs/aws_ec2_plugin.yaml
+++ b/configs/aws_ec2_plugin.yaml
@@ -167,7 +167,7 @@ jenkins:
         type: C59xlarge
         useEphemeralDevices: false
         zone: "us-west-2a"
-      - ami: "ami-0c169196f4a990b3e"
+      - ami: "ami-00e9cadd4c5aae19a"
         amiType:
           unixData:
             sshPort: "22"


### PR DESCRIPTION
This PR updates the AMI for Windows nodes which has the following updates: 

- Installed required security updates
- Set updated java version to default