### PR TITLE
Upgrade Jenkins to 2.426.3 LTS JDK11 (production)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.414.3-lts-jdk11
+FROM jenkins/jenkins:2.426.3-lts-jdk11
 
 # Using JENKINS_HOME and REF set on the base image
 ARG uid=1000

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,3 +1,4 @@
+analysis-model-api:11.15.0
 artifact-manager-s3:822.vf129d4836c31
 aws-global-configuration:128.ve2c5685a_09c3
 aws-java-sdk:1.12.529-406.vdeff15e5817d
@@ -13,10 +14,12 @@ email-ext:2.102
 external-monitor-job:215.v2e88e894db_f8
 github-branch-source:1741.va_3028eb_9fd21
 github-oauth:588.vf696a_350572a_
+git-server:114.v068a_c7cc2574
 greenballs:1.15.1
 job-dsl:1.86
 mailer:463.vedf8358e006b_
 matrix-auth:3.2.1
+matrix-project:822.824.v14451b_c0fd42
 pam-auth:1.10
 pipeline-aws:1.43
 pipeline-stage-view:2.33
@@ -25,7 +28,7 @@ remote-file:1.24
 saml:4.429.v9a_781a_61f1da_
 ssh-slaves:2.916.vd17b_43357ce4
 timestamper:1.26
-warnings-ng:10.5.0
+warnings-ng:10.7.0
 windows-slaves:1.8.1
 workflow-aggregator:596.v8c21c963d92d
 workflow-cps-global-lib:609.vd95673f149b_b


### PR DESCRIPTION
Update misc plugins to address vulnerabilities.

*Testing*
- upgraded Sandbox server first to ensure the instance launches, plugins don't report issues and vulnerability warnings are gone.